### PR TITLE
Update schema generation for routes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       timeout
     net-smtp (0.1.0)
     nio4r (2.5.8)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -205,6 +207,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -219,4 +222,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.19
+   2.3.26

--- a/lib/graphql_to_rest/components/request_bodies/routes_to_schemas.rb
+++ b/lib/graphql_to_rest/components/request_bodies/routes_to_schemas.rb
@@ -24,6 +24,8 @@ module GraphqlToRest
 
         def schemas
           routes.each.reduce({}) do |cached_schemas, route|
+            next cached_schemas if route.input_type.nil?
+
             new_schemas = components_schemas_for(route, cached_schemas)
             cached_schemas.merge(new_schemas)
           end

--- a/lib/graphql_to_rest/components/request_bodies/routes_to_schemas.rb
+++ b/lib/graphql_to_rest/components/request_bodies/routes_to_schemas.rb
@@ -24,8 +24,6 @@ module GraphqlToRest
 
         def schemas
           routes.each.reduce({}) do |cached_schemas, route|
-            next cached_schemas if route.input_type.nil?
-
             new_schemas = components_schemas_for(route, cached_schemas)
             cached_schemas.merge(new_schemas)
           end

--- a/lib/graphql_to_rest/components/request_bodies/type_to_schemas.rb
+++ b/lib/graphql_to_rest/components/request_bodies/type_to_schemas.rb
@@ -7,6 +7,12 @@ module GraphqlToRest
     module RequestBodies
       # Converts GraphQL type to OpenAPI requestBodies schemas
       class TypeToSchemas < GraphqlToRest::Components::Schemas::TypeToSchemas
+        def call
+          return {} if graphql_type.nil?
+
+          super
+        end
+
         private
 
         def schema_for_graphql_enum

--- a/lib/graphql_to_rest/paths/route_decorator.rb
+++ b/lib/graphql_to_rest/paths/route_decorator.rb
@@ -12,6 +12,8 @@ module GraphqlToRest
       end
 
       def input_type
+        return nil if action_config.graphql_input_type_path.empty?
+
         nesting_keys = action_config.graphql_input_type_path.map(&:to_s)
         graphql_schema_action.arguments[*nesting_keys].type
       end

--- a/lib/graphql_to_rest/paths/route_to_path_schema.rb
+++ b/lib/graphql_to_rest/paths/route_to_path_schema.rb
@@ -23,7 +23,7 @@ module GraphqlToRest
               'parameters' => parameters,
               'requestBody' => request_body,
               'responses' => responses
-            }
+            }.compact
           }
         }.deep_stringify_keys
       end
@@ -81,6 +81,8 @@ module GraphqlToRest
       end
 
       def request_body
+        return nil if input_type.nil?
+
         schema_builder.call_service(
           Paths::GraphqlToPathRequestBody,
           graphql_input: input_type

--- a/spec/lib/graphql_to_rest/components/request_bodies/type_to_schemas_spec.rb
+++ b/spec/lib/graphql_to_rest/components/request_bodies/type_to_schemas_spec.rb
@@ -51,5 +51,11 @@ RSpec.describe GraphqlToRest::Components::RequestBodies::TypeToSchemas do
         required: %w[name]
       )
     end
+
+    context 'when graphql_type is nil' do
+      let(:graphql_type) { nil }
+
+      it { is_expected.to eq({}) }
+    end
   end
 end

--- a/spec/lib/graphql_to_rest/paths/route_decorator_spec.rb
+++ b/spec/lib/graphql_to_rest/paths/route_decorator_spec.rb
@@ -13,10 +13,18 @@ RSpec.describe GraphqlToRest::Paths::RouteDecorator do
     end
 
     describe '#input_type' do
-      subject(:input_type) { route_decorator.input_type.to_type_signature }
+      subject(:input_type) { route_decorator.input_type }
 
       it 'returns correct input type' do
-        expect(input_type).to eq('UserCreateInput!')
+        expect(input_type.to_type_signature).to eq('UserCreateInput!')
+      end
+
+      context 'when route does not have graphql input type' do
+        let(:rails_route) do
+          rails_route_double('get', '/api/v1/:some_param/users/:id', "users#show")
+        end
+
+        it { is_expected.to be_nil }
       end
     end
 

--- a/spec/lib/graphql_to_rest/paths/route_to_path_schema_spec.rb
+++ b/spec/lib/graphql_to_rest/paths/route_to_path_schema_spec.rb
@@ -40,5 +40,14 @@ RSpec.describe GraphqlToRest::Paths::RouteToPathSchema do
       path_spec = call.fetch('/users').fetch('post')
       expect(path_spec.keys).to match_array(%w[parameters requestBody responses])
     end
+
+    context 'with route without input' do
+      let(:route) { route_double_for('users#show') }
+
+      it 'does not generate requestBody' do
+        path_spec = call.fetch('/users/{id}').fetch('get')
+        expect(path_spec.keys).not_to include('requestBody')
+      end
+    end
   end
 end

--- a/spec/support/rails_routes_helper.rb
+++ b/spec/support/rails_routes_helper.rb
@@ -30,6 +30,8 @@ module GraphqlToRest
         case action
         when 'users#create'
           route_double('post', '/api/v1/users(.:format)', "users#create")
+        when 'users#show'
+          route_double('get', '/api/v1/users/:id', "users#show")
         else
           raise "Unknown action: #{action}"
         end


### PR DESCRIPTION
This PR updates schema generation for routes without `graphql_input_type_path`.