### PR TITLE
Add 'id' and '__typename' fields to query output

### DIFF
--- a/lib/graphql_to_rest/controller/json_api.rb
+++ b/lib/graphql_to_rest/controller/json_api.rb
@@ -8,6 +8,8 @@ module GraphqlToRest
   module Controller
     # Configuration for OpenAPI controller
     module JsonApi
+      REQUIRED_OUTPUT_FIELDS = %w[id __typename].freeze
+
       module ClassMethods
         def open_api_configuration_class
           JsonApi::ControllerConfiguration
@@ -30,7 +32,7 @@ module GraphqlToRest
       end
 
       def action_output_fields
-        GraphqlToRest::Controller::JsonApi::FieldsetToGraphqlOutput.call(fieldset: fieldset)
+        GraphqlToRest::Controller::JsonApi::FieldsetToGraphqlOutput.call(fieldset: fieldset | REQUIRED_OUTPUT_FIELDS)
       end
     end
   end

--- a/spec/lib/graphql_to_rest/controller/json_api_spec.rb
+++ b/spec/lib/graphql_to_rest/controller/json_api_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GraphqlToRest::Controller::JsonApi do
 
     context 'without feilds in params' do
       it 'returns fieldset default value' do
-        expect(action_output_fields).to contain_exactly(:id, :email)
+        expect(action_output_fields).to contain_exactly(:id, :__typename, :email)
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe GraphqlToRest::Controller::JsonApi do
       end
 
       it 'returns specified fields' do
-        expect(action_output_fields).to contain_exactly(:id, :name)
+        expect(action_output_fields).to contain_exactly(:id, :__typename, :name)
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe GraphqlToRest::Controller::JsonApi do
       end
 
       it 'returns specified fields' do
-        expect(action_output_fields).to contain_exactly(:id, :name, { nested: [:field]})
+        expect(action_output_fields).to contain_exactly(:id, :__typename, :name, { nested: [:field]})
       end
     end
   end


### PR DESCRIPTION
Added `:id` and `:__typename` fields to GraphQL query output that are always included