### PR TITLE
Add support for graphql_context and field visibility

### DIFF
--- a/lib/graphql_to_rest/schema.rb
+++ b/lib/graphql_to_rest/schema.rb
@@ -9,9 +9,18 @@ module GraphqlToRest
   class Schema
     OPENAPI_VERSION = '3.0.2'
 
-    attr_reader :tags, :servers, :info, :security_schemes, :graphql_schema, :path_schemas_dir
+    attr_reader :tags, :servers, :info, :security_schemes, :graphql_schema, :path_schemas_dir, :graphql_context
 
-    def initialize(tags: [], servers: [], info: {}, security_schemes: [], graphql_schema:, path_schemas_dir:, rails_routes: nil)
+    def initialize(
+      graphql_schema:,
+      path_schemas_dir:,
+      tags: [],
+      servers: [],
+      info: {},
+      security_schemes: [],
+      rails_routes: nil,
+      graphql_context: {}
+    )
       @tags = tags
       @servers = servers
       @info = info
@@ -19,6 +28,7 @@ module GraphqlToRest
       @graphql_schema = graphql_schema
       @path_schemas_dir = path_schemas_dir
       @rails_routes = rails_routes || Rails.application.routes.routes
+      @graphql_context = graphql_context
     end
 
     def as_json

--- a/lib/graphql_to_rest/schema/basic/concerns/properties_parseable.rb
+++ b/lib/graphql_to_rest/schema/basic/concerns/properties_parseable.rb
@@ -6,7 +6,7 @@ module GraphqlToRest
   class Schema
     module Basic
       # Adds methods for parsing properties.
-      # Expects #type_parser and #allowed_property? to be defined.
+      # Expects #type_parser, #route, and #allowed_property? to be defined.
       module PropertiesParseable
         private
 
@@ -21,7 +21,11 @@ module GraphqlToRest
         end
 
         def unparsed_properties
-          inner_nullable_graphql_object.fields
+          inner_nullable_graphql_object.fields.select { |_name, field| field.visible?(graphql_context) }
+        end
+
+        def graphql_context
+          route.schema_builder.graphql_context
         end
 
         def unfiltered_property_parsers

--- a/spec/factories/schemas_factory.rb
+++ b/spec/factories/schemas_factory.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
     graphql_schema { GraphqlToRest::DummyAppShared::Schema }
     path_schemas_dir { 'spec/fixtures/apps/dummy_app_shared' }
     rails_routes { build_list(:fake_rails_route, 1, routes_params) }
+    graphql_context { {} }
 
     trait :basic do
       route_app { :dummy_app_basic }
@@ -59,7 +60,8 @@ FactoryBot.define do
         security_schemes: security_schemes,
         graphql_schema: graphql_schema,
         path_schemas_dir: path_schemas_dir,
-        rails_routes: rails_routes
+        rails_routes: rails_routes,
+        graphql_context: graphql_context
       )
     end
   end

--- a/spec/lib/graphql_to_rest/schema/basic/concerns/properties_parseable_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/basic/concerns/properties_parseable_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphqlToRest::Schema::Basic::PropertiesParseable do # rubocop:disable RSpec/FilePath
+  let(:dummy_class) do
+    Class.new do
+      include GraphqlToRest::Schema::Basic::PropertiesParseable
+
+      attr_reader :route, :type_parser
+
+      def initialize(route:, type_parser:)
+        @route = route
+        @type_parser = type_parser
+      end
+    end
+  end
+
+  let(:dummy_instance) { dummy_class.new(route: route, type_parser: type_parser) }
+  let(:route) { build(:route_decorator) }
+  let(:unparsed_type) { route.return_type }
+  let(:type_parser) do
+    GraphqlToRest::TypeParsers::GraphqlTypeParser.new(unparsed_type: unparsed_type)
+  end
+
+  describe '#unparsed_properties' do
+    let(:unparsed_properties) { dummy_instance.send(:unparsed_properties) }
+    let(:field) { unparsed_type.fields['id'] }
+
+    context 'when all fields visible' do
+      it 'returns visible properties' do
+        expect(unparsed_properties.keys).to include(field.name)
+      end
+    end
+
+    context 'when some fields not visible' do
+      before do
+        allow(field).to receive(:visible?).and_return(false)
+      end
+
+      it 'returns only visible properties' do
+        expect(unparsed_properties.keys).not_to include(field.name)
+      end
+
+      it 'checks visibility with graphql context' do
+        unparsed_properties
+        expect(field).to have_received(:visible?).with(route.schema_builder.graphql_context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently all graphql fields are included in openapi.json file even if those fields are hidden under some conditions. This PR adds a possibility to pass graphql_context and also checks for field visibility using that context