### PR TITLE
Fix connection type parsing

### DIFF
--- a/lib/graphql_to_rest/schema/fetch_referenced_graphql_names.rb
+++ b/lib/graphql_to_rest/schema/fetch_referenced_graphql_names.rb
@@ -28,7 +28,8 @@ module GraphqlToRest
         return [] if compound_field.blank?
 
         field, rest_fields = shift_field(compound_field)
-        type = parent_type.unwrap.fields[field].type
+        unwrapped_parent = build_type_parser(parent_type).inner_nullable_graphql_object
+        type = unwrapped_parent.fields[field].type
         parser = build_type_parser(type)
 
         return [] unless parser.deeply_object?

--- a/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
+++ b/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
@@ -24,7 +24,7 @@ module GraphqlToRest
       rattr_initialize %i[unparsed_type!]
 
       def open_api_type_name
-        (basic_type_name || graphql_name)
+        basic_type_name || graphql_name
       end
 
       def inner_nullable_graphql_object

--- a/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
+++ b/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
@@ -24,7 +24,7 @@ module GraphqlToRest
       rattr_initialize %i[unparsed_type!]
 
       def open_api_type_name
-        basic_type_name || graphql_name
+        (basic_type_name || graphql_name)
       end
 
       def inner_nullable_graphql_object
@@ -87,7 +87,9 @@ module GraphqlToRest
       end
 
       def unwrap_type(unwraped_type)
-        if unwraped_type.is_a?(GraphQL::Schema::Wrapper)
+        if unwraped_type.is_a?(Class) && unwraped_type < GraphQL::Types::Relay::BaseConnection
+          unwrap_type(unwraped_type.node_type)
+        elsif unwraped_type.is_a?(GraphQL::Schema::Wrapper)
           unwrap_type(unwraped_type.of_type)
         else
           unwraped_type

--- a/spec/factories/fake_rails_routes_factory.rb
+++ b/spec/factories/fake_rails_routes_factory.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
   factory :fake_rails_route, class: 'GraphqlToRest::Test::RailsRoutesHelper::FakeRailsRoute' do
     transient do
       to { 'users#create' }
-      path_suffix { %[update show destroy].include?(action) ? '/:id' : '' }
+      path_suffix { %w[update show destroy].include?(action) ? '/:id' : '' }
     end
-    path { "/api/v1/#{controller}#{path_suffix}(.:format)"  }
+    path { "/api/v1/#{controller}#{path_suffix}(.:format)" }
     controller { to.split('#').first }
     action { to.split('#').last }
     http_method do
@@ -13,6 +13,10 @@ FactoryBot.define do
       mapping.fetch(action, 'get')
     end
     app { 'dummy_app_json_api' }
+
+    trait :users_paginated do
+      to { 'users#index_paginated' }
+    end
 
     trait :basic do
       app { 'dummy_app_basic' }

--- a/spec/factories/route_decorators_factory.rb
+++ b/spec/factories/route_decorators_factory.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       to { 'users#show' }
     end
 
+    trait :users_paginated do
+      to { 'users#index_paginated' }
+    end
+
     initialize_with do
       new(
         rails_route: rails_route,

--- a/spec/factories/schemas_factory.rb
+++ b/spec/factories/schemas_factory.rb
@@ -39,7 +39,12 @@ FactoryBot.define do
     end
     graphql_schema { GraphqlToRest::DummyAppShared::Schema }
     path_schemas_dir { 'spec/fixtures/apps/dummy_app_shared' }
-    rails_routes { build_list(:fake_rails_route, 1, routes_params) }
+    rails_routes do
+      [
+        build(:fake_rails_route, routes_params),
+        build(:fake_rails_route, :users_paginated, routes_params)
+      ]
+    end
     graphql_context { {} }
 
     trait :basic do

--- a/spec/fixtures/apps/dummy_app_json_api/app/controllers/api/v1/users_controller.rb
+++ b/spec/fixtures/apps/dummy_app_json_api/app/controllers/api/v1/users_controller.rb
@@ -17,6 +17,13 @@ module GraphqlToRest
                .default_value(%i[id email])
             end
 
+            c.action(:index_paginated) do |a|
+              a.graphql_action(:usersPaginated)
+              a.fieldset_parameter
+               .nested_fields('posts.id')
+               .default_value(%i[id email])
+            end
+
             c.action(:create) do |a|
               a.graphql_action(:createUser)
               a.fieldset_parameter

--- a/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
+++ b/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
@@ -126,6 +126,77 @@
             }
           }
         }
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "name": "fields[User]",
+            "description": "Comma separated list of #/components/schemas/User fields that must be returned",
+            "schema": {
+              "items": {
+                "type": "string",
+                "enum": [
+                  "email",
+                  "fullName",
+                  "gender",
+                  "id",
+                  "posts.id"
+                ]
+              },
+              "type": "array",
+              "default": "id,email"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated users list (success response)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "links": {
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "related": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "$ref": "#/components/schemas/User"
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/spec/fixtures/apps/dummy_app_shared/app/graphql/types/query_type.rb
+++ b/spec/fixtures/apps/dummy_app_shared/app/graphql/types/query_type.rb
@@ -6,14 +6,20 @@ module GraphqlToRest
   module DummyAppShared
     module Types
       class QueryType < GraphQL::Schema::Object
-        description "The query root of this schema"
+        description 'The query root of this schema'
 
-        field :user, Types::UserType, "Find a User by ID" do
+        field :user, Types::UserType, 'Find a User by ID' do
           argument :id, ID
         end
 
+        field :usersPaginated, Types::UserType.connection_type, 'Paginated users list'
+
         def user(id:)
           OpenStruct.new(id: id, email: 'john.doe@example.com', full_name: 'John Doe')
+        end
+
+        def users_paginated
+          [user(id: 1)]
         end
       end
     end

--- a/spec/lib/graphql_to_rest/schema/fetch_referenced_graphql_names_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/fetch_referenced_graphql_names_spec.rb
@@ -11,5 +11,13 @@ RSpec.describe GraphqlToRest::Schema::FetchReferencedGraphqlNames do
     it 'returns graphql names used in given routes' do
       expect(call).to match_array(%w[User Post])
     end
+
+    context 'when route points to paginated type' do
+      let(:route) { build(:route_decorator, :users_paginated) }
+
+      it 'returns graphql connection names used in given routes' do
+        expect(call).to match_array(%w[User Post])
+      end
+    end
   end
 end

--- a/spec/lib/graphql_to_rest/type_parsers/graphql_type_parser_spec.rb
+++ b/spec/lib/graphql_to_rest/type_parsers/graphql_type_parser_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe GraphqlToRest::TypeParsers::GraphqlTypeParser do
         expect(inner_nullable_graphql_object).to eq(GraphqlToRest::DummyAppShared::Types::UserType)
       end
     end
+
+    context 'when type is a Connection' do
+      let(:unparsed_type) { GraphqlToRest::DummyAppShared::Types::UserType.connection_type }
+
+      it 'returns unwrapped type' do
+        expect(inner_nullable_graphql_object).to eq(GraphqlToRest::DummyAppShared::Types::UserType)
+      end
+    end
   end
 
   describe '#deeply_scalar?' do


### PR DESCRIPTION
We incorrectly parse connection type, which breaks JSON:API style fieldset config. This PR improves this part by fixing type unwrap logic. Seems like there are more similar issues, but this PR handles only fieldset part.