### PR TITLE
Include graphql Connection types in component/schemas

### DIFF
--- a/lib/graphql_to_rest/schema/basic/components/schemas/type_to_schemas.rb
+++ b/lib/graphql_to_rest/schema/basic/components/schemas/type_to_schemas.rb
@@ -80,6 +80,13 @@ module GraphqlToRest
             def type_parser
               @type_parser ||= type_parser_for(graphql_type)
             end
+
+            def type_parser_for(type)
+              TypeParsers::GraphqlTypeParser.new(
+                unparsed_type: type,
+                unwrap_connection: false
+              )
+            end
           end
         end
       end

--- a/lib/graphql_to_rest/schema/basic/paths/graphql_to_success_response.rb
+++ b/lib/graphql_to_rest/schema/basic/paths/graphql_to_success_response.rb
@@ -53,7 +53,7 @@ module GraphqlToRest
             if route_description
               "#{route_description} (success response)"
             else
-              "Success response"
+              'Success response'
             end
           end
 
@@ -83,7 +83,10 @@ module GraphqlToRest
           end
 
           def type_parser
-            @type_parser ||= TypeParsers::GraphqlTypeParser.new(unparsed_type: type)
+            @type_parser ||= TypeParsers::GraphqlTypeParser.new(
+              unparsed_type: type,
+              unwrap_connection: false
+            )
           end
         end
       end

--- a/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
+++ b/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
@@ -181,7 +181,7 @@
                       "type": "object",
                       "properties": {
                         "attributes": {
-                          "$ref": "#/components/schemas/User"
+                          "$ref": "#/components/schemas/UserConnection"
                         }
                       },
                       "required": [
@@ -255,6 +255,17 @@
           "fullName",
           "id"
         ]
+      },
+      "UserConnection": {
+        "type": "object",
+        "properties": {
+          "nodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
       },
       "LocationInput": {
         "type": "object",

--- a/spec/lib/graphql_to_rest/schema/basic/paths/graphql_to_success_response_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/basic/paths/graphql_to_success_response_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GraphqlToRest::Schema::Basic::Paths::GraphqlToSuccessResponse do
     let(:type) { GraphqlToRest::DummyAppShared::Types::UserType }
     let(:route) { build(:route_decorator) }
 
-    it 'returns correct schema' do
+    it 'returns correct schema' do # rubocop:disable RSpec/ExampleLength
       actual_schema = call[:'200'][:content][:'application/json'][:schema]
       expect(actual_schema[:properties].keys).to match_array(%i[links meta data])
 
@@ -20,6 +20,20 @@ RSpec.describe GraphqlToRest::Schema::Basic::Paths::GraphqlToSuccessResponse do
       expect(actual_data[:properties]).to eq(
         attributes: { '$ref': '#/components/schemas/User' }
       )
+    end
+
+    context 'when graphql type is a connection' do
+      let(:type) { GraphqlToRest::DummyAppShared::Types::UserType.connection_type }
+
+      it 'returns correct schema' do # rubocop:disable RSpec/ExampleLength
+        actual_schema = call[:'200'][:content][:'application/json'][:schema]
+        expect(actual_schema[:properties].keys).to match_array(%i[links meta data])
+
+        actual_data = actual_schema[:properties][:data]
+        expect(actual_data[:properties]).to eq(
+          attributes: { '$ref': '#/components/schemas/UserConnection' }
+        )
+      end
     end
 
     context 'when graphql action has description' do


### PR DESCRIPTION
Currently, we skip Connection types in responses and component/schemas. This PR makes it visible again