### PR TITLE
Add support for GraphQL input parameters

### DIFF
--- a/lib/graphql_to_rest/controller/basic/action_configuration.rb
+++ b/lib/graphql_to_rest/controller/basic/action_configuration.rb
@@ -7,6 +7,8 @@ module GraphqlToRest
     module Basic
       # Configuration for OpenAPI controller action
       class ActionConfiguration
+        attr_reader :query_parameters, :path_parameters
+
         def initialize(controller_config:)
           @controller_config = controller_config
           @query_parameters = {}
@@ -54,7 +56,7 @@ module GraphqlToRest
         attr_reader :controller_config
 
         def build_parameter_configuration(**kwargs)
-          parameter_configuration_class.new(kwargs)
+          parameter_configuration_class.new(**kwargs)
         end
       end
     end

--- a/lib/graphql_to_rest/controller/basic/parameter_configuration.rb
+++ b/lib/graphql_to_rest/controller/basic/parameter_configuration.rb
@@ -5,12 +5,38 @@ module GraphqlToRest
     module Basic
       # Configuration for OpenAPI controller action parameter
       class ParameterConfiguration
-        rattr_initialize %i[name!]
+        attr_reader :name
+
+        def initialize(name:)
+          @name = name
+          @required = true
+        end
+
+        def required
+          @required = true
+          self
+        end
+
+        def optional
+          @required = false
+          self
+        end
+
+        def required?
+          @required
+        end
 
         def default_value(value = nil)
           return @default_value if value.nil?
 
           @default_value = value
+          self
+        end
+
+        def graphql_input_type_path(nesting = nil)
+          return @graphql_input_type_path || [] if nesting.nil?
+
+          @graphql_input_type_path = Array(nesting)
           self
         end
       end

--- a/lib/graphql_to_rest/schema.rb
+++ b/lib/graphql_to_rest/schema.rb
@@ -36,7 +36,7 @@ module GraphqlToRest
         **general_info,
         paths: paths,
         components: {
-          schemas: components_schemas.merge(components_request_bodies),
+          schemas: all_components_schemas,
           securitySchemes: security_schemes
         }
       }
@@ -94,6 +94,10 @@ module GraphqlToRest
     private
 
     attr_reader :rails_routes
+
+    def all_components_schemas
+      components_schemas.merge(components_request_bodies)
+    end
 
     def server_urls
       @server_urls ||= servers.map { _1[:url] }

--- a/lib/graphql_to_rest/schema/basic/components/request_bodies/type_to_schemas.rb
+++ b/lib/graphql_to_rest/schema/basic/components/request_bodies/type_to_schemas.rb
@@ -17,10 +17,6 @@ module GraphqlToRest
 
             private
 
-            def schema_for_graphql_enum
-              {}
-            end
-
             def unparsed_properties
               inner_nullable_graphql_object.arguments
             end

--- a/lib/graphql_to_rest/schema/basic/paths/route_to_parameters.rb
+++ b/lib/graphql_to_rest/schema/basic/paths/route_to_parameters.rb
@@ -6,45 +6,74 @@ module GraphqlToRest
       module Paths
         # Converts GraphQL type to OpenAPI path parameters
         class RouteToParameters
-          DEFAULT_PARAMETER_OPTIONS = {
-            'ctx_token' => {
-              example: 'c1d1',
-              description: 'Context token'
-            }
+          OBJECT_QUERY_PARAMETER_PARAMS = {
+            style: 'deepObject',
+            explode: true
           }.freeze
 
           method_object %i[route!]
 
           def call
-            route.path_parameters.map { path_parameter(_1) }
+            parameters = path_parameters + query_parameters
+            parameters.map { |parameter_schema| sorted_hash(parameter_schema) }
           end
 
           private
 
           delegate :action_config, :return_type, to: :route, private: true
 
-          def fieldset_parameter
-            route.open_api_json_for('paths.{path}.{method}.parameters:fieldset')
+          def path_parameters
+            route.path_parameters.sort.map do |parameter_name|
+              path_parameter_schema(parameter_name)
+            end
           end
 
-          def extra_schema_params_for(parameter_name)
-            default_params = DEFAULT_PARAMETER_OPTIONS[parameter_name] || {}
-            default_value = action_config.path_parameter(parameter_name).default_value
-            return default_params if default_value.nil?
-
-            default_params.merge(default: default_value)
+          def query_parameters
+            action_config.query_parameters.values.sort_by(&:name).map do |parameter|
+              query_parameter_schema(parameter)
+            end
           end
 
-          def path_parameter(parameter_name)
+          def query_parameter_schema(parameter)
+            type_parser = parameter_type_parser(parameter)
+            extra_params = type_parser.deeply_input_object? ? OBJECT_QUERY_PARAMETER_PARAMS : {}
+
             {
-              name: parameter_name,
-              in: 'path',
-              required: true,
-              schema: {
-                type: 'string',
-                **extra_schema_params_for(parameter_name)
-              }.compact
+              **parameter_schema(parameter),
+              **extra_params,
+              in: 'query',
+              allowReserved: true
             }
+          end
+
+          def path_parameter_schema(parameter_name)
+            parameter = action_config.path_parameter(parameter_name)
+
+            {
+              **parameter_schema(parameter),
+              in: 'path'
+            }
+          end
+
+          def parameter_schema(parameter)
+            schema = {
+              name: parameter.name,
+              required: parameter.required?,
+              schema: parameter_type_parser(parameter).open_api_schema_reference,
+            }
+            schema[:default] = parameter.default_value if parameter.default_value
+            schema
+          end
+
+          def parameter_type_parser(parameter)
+            unparsed_type = route.input_type_for(parameter) || GraphQL::Types::String
+            GraphqlToRest::TypeParsers::GraphqlInputTypeParser.new(
+              unparsed_type: unparsed_type
+            )
+          end
+
+          def sorted_hash(hash)
+            hash.sort_by { |k, _| k.to_s }.to_h
           end
         end
       end

--- a/lib/graphql_to_rest/schema/basic/paths/route_to_path_schema.rb
+++ b/lib/graphql_to_rest/schema/basic/paths/route_to_path_schema.rb
@@ -17,8 +17,8 @@ module GraphqlToRest
           private
 
           delegate :http_method, :open_api_path, :action_config, :return_type,
-                  :input_type, :schema_builder,
-                  to: :route, private: true
+                   :input_type, :schema_builder,
+                   to: :route, private: true
 
           delegate :path_schemas_dir, to: :schema_builder, private: true
 

--- a/lib/graphql_to_rest/schema/json_api/components/schemas/type_to_schemas.rb
+++ b/lib/graphql_to_rest/schema/json_api/components/schemas/type_to_schemas.rb
@@ -18,8 +18,6 @@ module GraphqlToRest
               super || referenced_graphql_names.include?(property_parser.graphql_name)
             end
 
-            private
-
             def referenced_graphql_names
               @referenced_graphql_names ||= route.schema_builder.referenced_graphql_names
             end

--- a/lib/graphql_to_rest/schema/json_api/paths/route_to_fieldset_parameter.rb
+++ b/lib/graphql_to_rest/schema/json_api/paths/route_to_fieldset_parameter.rb
@@ -21,9 +21,10 @@ module GraphqlToRest
             {
               **FIELDSET_BASIC_SPECS,
               name: parameter_name,
+              allowReserved: true,
               description: description,
               schema: schema
-            }
+            }.then { |schema| sorted_hash(schema) }
           end
 
           private
@@ -43,17 +44,12 @@ module GraphqlToRest
             {
               items: items_open_api_json,
               type: 'array',
-              **default_value_params,
-              **extra_params
-            }
+              **default_value_params
+            }.then { |schema| sorted_hash(schema) }
           end
 
           def items_open_api_json
             route.open_api_json_for('paths.{path}.{method}.parameters.items:fieldset')
-          end
-
-          def extra_params
-            RouteToParameters::DEFAULT_PARAMETER_OPTIONS[parameter_name] || {}
           end
 
           def default_value_params
@@ -73,6 +69,10 @@ module GraphqlToRest
 
           def build_type_parser(unparsed_type)
             TypeParsers::GraphqlTypeParser.new(unparsed_type: unparsed_type)
+          end
+
+          def sorted_hash(hash)
+            hash.sort_by { |k, _| k.to_s }.to_h
           end
         end
       end

--- a/lib/graphql_to_rest/schema/route_decorator.rb
+++ b/lib/graphql_to_rest/schema/route_decorator.rb
@@ -15,10 +15,17 @@ module GraphqlToRest
       end
 
       def input_type
-        return nil if action_config.graphql_input_type_path.empty?
+        input_type_for(action_config)
+      end
 
-        nesting_keys = action_config.graphql_input_type_path.map(&:to_s)
-        graphql_schema_action.arguments[*nesting_keys].type
+      def input_type_for(parameter)
+        return nil if parameter.graphql_input_type_path.empty?
+
+        nesting_keys = parameter.graphql_input_type_path.map(&:to_s)
+        nesting_keys.reduce(graphql_schema_action) do |type, key|
+          final_type = type.respond_to?(:unwrap) ? type.unwrap : type
+          final_type.arguments.fetch(key).type
+        end
       end
 
       def return_type

--- a/lib/graphql_to_rest/schema/routes_to_components_schemas.rb
+++ b/lib/graphql_to_rest/schema/routes_to_components_schemas.rb
@@ -15,6 +15,11 @@ module GraphqlToRest
       private
 
       def components_schemas_for(route, cached_schemas)
+        action_components_schemas(route, cached_schemas)
+          .merge(parameters_component_schemas(route, cached_schemas))
+      end
+
+      def action_components_schemas(route, cached_schemas)
         route.open_api_json_for(
           'components.schemas',
           graphql_type: route.return_type,
@@ -22,11 +27,29 @@ module GraphqlToRest
         )
       end
 
+      def parameters_component_schemas(route, cached_schemas)
+        route.action_config.query_parameters.values.reduce({}) do |schemas, parameter|
+          schemas.merge(
+            route.open_api_json_for(
+              'components.schemas:requestBodies',
+              graphql_type: parameter_graphql_input_type(route, parameter),
+              cached_schemas: cached_schemas
+            )
+          )
+        end
+      end
+
       def schemas
         routes.each.reduce({}) do |cached_schemas, route|
           new_schemas = components_schemas_for(route, cached_schemas)
           cached_schemas.merge(new_schemas)
         end
+      end
+
+      def parameter_graphql_input_type(route, parameter)
+        return nil if parameter.graphql_input_type_path.empty?
+
+        route.input_type_for(parameter)
       end
     end
   end

--- a/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
+++ b/lib/graphql_to_rest/type_parsers/graphql_type_parser.rb
@@ -43,6 +43,10 @@ module GraphqlToRest
         inner_nullable_graphql_object < GraphQL::Schema::Object
       end
 
+      def deeply_input_object?
+        inner_nullable_graphql_object < GraphQL::Schema::InputObject
+      end
+
       def deeply_enum?
         inner_nullable_graphql_object < GraphQL::Schema::Enum
       end

--- a/spec/factories/fake_rails_routes_factory.rb
+++ b/spec/factories/fake_rails_routes_factory.rb
@@ -4,8 +4,9 @@ FactoryBot.define do
     transient do
       to { 'users#create' }
       path_suffix { %w[update show destroy].include?(action) ? '/:id' : '' }
+      path_action { %w[index create update show destroy].include?(action) ? '' : "/#{action}" }
     end
-    path { "/api/v1/#{controller}#{path_suffix}(.:format)" }
+    path { "/api/v1/#{controller}#{path_suffix}#{path_action}(.:format)" }
     controller { to.split('#').first }
     action { to.split('#').last }
     http_method do
@@ -16,6 +17,10 @@ FactoryBot.define do
 
     trait :users_paginated do
       to { 'users#index_paginated' }
+    end
+
+    trait :users_index_explicit_params do
+      to { 'users#index_explicit_params' }
     end
 
     trait :basic do

--- a/spec/factories/route_decorators_factory.rb
+++ b/spec/factories/route_decorators_factory.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       to { 'users#index_paginated' }
     end
 
+    trait :users_index_explicit_params do
+      to { 'users#index_explicit_params' }
+    end
+
     initialize_with do
       new(
         rails_route: rails_route,

--- a/spec/factories/schemas_factory.rb
+++ b/spec/factories/schemas_factory.rb
@@ -42,7 +42,8 @@ FactoryBot.define do
     rails_routes do
       [
         build(:fake_rails_route, routes_params),
-        build(:fake_rails_route, :users_paginated, routes_params)
+        build(:fake_rails_route, :users_paginated, routes_params),
+        build(:fake_rails_route, :users_index_explicit_params, routes_params)
       ]
     end
     graphql_context { {} }

--- a/spec/fixtures/apps/dummy_app_json_api/app/controllers/api/v1/users_controller.rb
+++ b/spec/fixtures/apps/dummy_app_json_api/app/controllers/api/v1/users_controller.rb
@@ -18,6 +18,21 @@ module GraphqlToRest
             end
 
             c.action(:index_paginated) do |a|
+              a.query_parameter(:filter).graphql_input_type_path(:filter)
+              a.graphql_action(:usersPaginated)
+            end
+
+            c.action(:index_explicit_params) do |a|
+              a.query_parameter('filter[status]')
+               .optional
+               .graphql_input_type_path(%i[filter status])
+               .default_value('ACTIVE')
+              a.query_parameter('filter[name]')
+               .optional
+               .graphql_input_type_path(%i[filter name])
+              a.query_parameter('filter[id]')
+               .optional
+               .graphql_input_type_path(%i[filter id])
               a.graphql_action(:usersPaginated)
             end
 

--- a/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
+++ b/spec/fixtures/apps/dummy_app_json_api/public/openapi.json
@@ -34,13 +34,14 @@
       "post": {
         "parameters": [
           {
-            "in": "query",
-            "style": "form",
-            "explode": false,
-            "required": false,
-            "name": "fields[User]",
+            "allowReserved": true,
             "description": "Comma separated list of #/components/schemas/User fields that must be returned",
+            "explode": false,
+            "in": "query",
+            "name": "fields[User]",
+            "required": false,
             "schema": {
+              "default": "id,email",
               "items": {
                 "type": "string",
                 "enum": [
@@ -51,9 +52,9 @@
                   "posts.id"
                 ]
               },
-              "type": "array",
-              "default": "id,email"
-            }
+              "type": "array"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -126,17 +127,20 @@
             }
           }
         }
-      },
+      }
+    },
+    "/users/index_paginated": {
       "get": {
         "parameters": [
           {
-            "in": "query",
-            "style": "form",
-            "explode": false,
-            "required": false,
-            "name": "fields[User]",
+            "allowReserved": true,
             "description": "Comma separated list of #/components/schemas/User fields that must be returned",
+            "explode": false,
+            "in": "query",
+            "name": "fields[User]",
+            "required": false,
             "schema": {
+              "default": "id,email",
               "items": {
                 "type": "string",
                 "enum": [
@@ -147,8 +151,127 @@
                   "posts.id"
                 ]
               },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "allowReserved": true,
+            "explode": true,
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/UsersFilter"
+            },
+            "style": "deepObject"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated users list (success response)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "links": {
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "related": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "$ref": "#/components/schemas/UserConnection"
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/index_explicit_params": {
+      "get": {
+        "parameters": [
+          {
+            "allowReserved": true,
+            "description": "Comma separated list of #/components/schemas/User fields that must be returned",
+            "explode": false,
+            "in": "query",
+            "name": "fields[User]",
+            "required": false,
+            "schema": {
+              "default": "id,email",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "email",
+                  "fullName",
+                  "gender",
+                  "id",
+                  "posts.id"
+                ]
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "allowReserved": true,
+            "in": "query",
+            "name": "filter[id]",
+            "required": false,
+            "schema": {
               "type": "array",
-              "default": "id,email"
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "allowReserved": true,
+            "in": "query",
+            "name": "filter[name]",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "allowReserved": true,
+            "default": "ACTIVE",
+            "in": "query",
+            "name": "filter[status]",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/StatusEnum"
+              }
             }
           }
         ],
@@ -228,6 +351,13 @@
           "id"
         ]
       },
+      "StatusEnum": {
+        "type": "string",
+        "enum": [
+          "Active",
+          "Inactive"
+        ]
+      },
       "User": {
         "type": "object",
         "properties": {
@@ -266,6 +396,31 @@
             }
           }
         }
+      },
+      "UsersFilter": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StatusEnum"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status"
+        ]
       },
       "LocationInput": {
         "type": "object",

--- a/spec/fixtures/apps/dummy_app_shared/app/graphql/types/query_type.rb
+++ b/spec/fixtures/apps/dummy_app_shared/app/graphql/types/query_type.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './user_type'
+require_relative './users_filter_input_type'
 
 module GraphqlToRest
   module DummyAppShared
@@ -12,13 +13,15 @@ module GraphqlToRest
           argument :id, ID
         end
 
-        field :usersPaginated, Types::UserType.connection_type, 'Paginated users list'
+        field :usersPaginated, Types::UserType.connection_type, 'Paginated users list' do
+          argument :filter, Types::UsersFilterInputTYpe
+        end
 
         def user(id:)
           OpenStruct.new(id: id, email: 'john.doe@example.com', full_name: 'John Doe')
         end
 
-        def users_paginated
+        def users_paginated(filter:)
           [user(id: 1)]
         end
       end

--- a/spec/fixtures/apps/dummy_app_shared/app/graphql/types/status_enum.rb
+++ b/spec/fixtures/apps/dummy_app_shared/app/graphql/types/status_enum.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module GraphqlToRest
+  module DummyAppShared
+    module Types
+      class StatusEnum < GraphQL::Schema::Enum
+        graphql_name 'StatusEnum'
+
+        value 'Active'
+        value 'Inactive'
+      end
+    end
+  end
+end

--- a/spec/fixtures/apps/dummy_app_shared/app/graphql/types/users_filter_input_type.rb
+++ b/spec/fixtures/apps/dummy_app_shared/app/graphql/types/users_filter_input_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'graphql'
+require_relative 'status_enum'
+
+module GraphqlToRest
+  module DummyAppShared
+    module Types
+      class UsersFilterInputTYpe < GraphQL::Schema::InputObject
+        graphql_name 'UsersFilter'
+
+        argument :id, type: [ID]
+        argument :status, type: [StatusEnum]
+        argument :name, type: String
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_to_rest/controller/basic/parameter_configuration_spec.rb
+++ b/spec/lib/graphql_to_rest/controller/basic/parameter_configuration_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphqlToRest::Controller::Basic::ParameterConfiguration do
+  subject(:config) { described_class.new(name: name) }
+
+  let(:name) { 'some_param' }
+
+  describe '#default_value' do
+    subject(:default_value) { config.default_value }
+
+    context 'when no value is set' do
+      it 'returns nil' do
+        expect(default_value).to be_nil
+      end
+    end
+
+    context 'when value is set' do
+      let(:value) { 'some_value' }
+
+      before do
+        config.default_value(value)
+      end
+
+      it 'returns value' do
+        expect(default_value).to eq(value)
+      end
+    end
+  end
+
+  describe '#graphql_input_type_path' do
+    subject(:graphql_input_type_path) { config.graphql_input_type_path }
+
+    context 'when no value is set' do
+      it 'returns empty array' do
+        expect(graphql_input_type_path).to eq([])
+      end
+    end
+
+    context 'when value is set' do
+      let(:value) { 'some_path' }
+
+      before do
+        config.graphql_input_type_path(value)
+      end
+
+      it 'returns value wrapped in array' do
+        expect(graphql_input_type_path).to eq([value])
+      end
+    end
+  end
+
+  describe '#required' do
+    before do
+      config.optional
+    end
+
+    it 'changes required? to true' do
+      expect { config.required }
+        .to change(config, :required?).from(false).to(true)
+    end
+  end
+
+  describe '#optional' do
+    before do
+      config.required
+    end
+
+    it 'changes required? to false' do
+      expect { config.optional }
+        .to change(config, :required?).from(true).to(false)
+    end
+  end
+end

--- a/spec/lib/graphql_to_rest/schema/basic/components/request_bodies/type_to_schemas_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/basic/components/request_bodies/type_to_schemas_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GraphqlToRest::Schema::Basic::Components::RequestBodies::TypeToSc
     let(:cached_schemas) { {} }
 
     it 'returns correct schemas for return type and inner types' do
-      expect(call.keys).to match_array(%w[UserCreateInput LocationInput WishItemInput])
+      expect(call.keys).to match_array(%w[UserCreateInput LocationInput WishItemInput GenderEnum])
 
       expect(call['UserCreateInput']).to eq(
         type: 'object',

--- a/spec/lib/graphql_to_rest/schema/basic/paths/route_to_parameters_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/basic/paths/route_to_parameters_spec.rb
@@ -6,20 +6,84 @@ RSpec.describe GraphqlToRest::Schema::Basic::Paths::RouteToParameters do
       described_class.call(route: route)
     end
 
-    let(:route) { build(:route_decorator, path: '/api/v1/:some_param/users(.:format)') }
+    context 'when route has path parameters' do
+      let(:route) { build(:route_decorator, path: '/api/v1/:some_param/users(.:format)') }
 
-    it 'returns correct parameters' do
-      expect(call.count).to eq(1)
-      expect(call).to eq(
-        [
-          {
-            name: 'some_param',
-            in: 'path',
-            required: true,
+      it 'returns correct parameters', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        expect(call.count).to eq(1)
+        expect(call).to eq(
+          [
+            {
+              name: 'some_param',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' }
+            }
+          ]
+        )
+      end
+    end
+
+    context 'when route has query parameters' do
+      let(:route) { build(:route_decorator, :users_paginated) }
+
+      context 'when query parameter is an object' do
+        it 'returns correct parameters', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+          expect(call.count).to eq(1)
+          expect(call).to eq(
+            [
+              {
+                name: 'filter',
+                in: 'query',
+                required: true,
+                schema: { '$ref' => '#/components/schemas/UsersFilter' },
+                style: 'deepObject',
+                allowReserved: true,
+                explode: true
+              }
+            ]
+          )
+        end
+      end
+
+      context 'with multiple query parameters' do
+        let(:route) { build(:route_decorator, :users_index_explicit_params) }
+
+        it 'returns correct parameters', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+          expect(call.count).to eq(3)
+
+          expect(call[0]).to eq(
+            name: 'filter[id]',
+            in: 'query',
+            required: false,
+            allowReserved: true,
+            schema: {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          )
+
+          expect(call[1]).to eq(
+            name: 'filter[name]',
+            in: 'query',
+            required: false,
+            allowReserved: true,
             schema: { type: 'string' }
-          }
-        ]
-      )
+          )
+
+          expect(call[2]).to eq(
+            name: 'filter[status]',
+            in: 'query',
+            required: false,
+            default: 'ACTIVE',
+            allowReserved: true,
+            schema: {
+              type: 'array',
+              items: { '$ref' => '#/components/schemas/StatusEnum' }
+            }
+          )
+        end
+      end
     end
   end
 end

--- a/spec/lib/graphql_to_rest/schema/json_api/paths/route_to_fieldset_parameter_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/json_api/paths/route_to_fieldset_parameter_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe GraphqlToRest::Schema::JsonApi::Paths::RouteToFieldsetParameter d
         required: false,
         style: 'form',
         explode: false,
+        allowReserved: true,
         schema: {
           type: 'array',
           default: 'id,email',

--- a/spec/lib/graphql_to_rest/schema/route_decorator_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/route_decorator_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe GraphqlToRest::Schema::RouteDecorator do
       end
     end
 
+    describe '#input_type_for' do
+      subject(:input_type_for) { route_decorator.input_type_for(parameter) }
+
+      let(:rails_route) { build(:fake_rails_route, :users_paginated) }
+      let(:parameter) { route_decorator.action_config.query_parameter(:filter) }
+
+      it 'returns correct input type' do
+        expect(input_type_for.to_type_signature).to eq('UsersFilter!')
+      end
+    end
+
     describe '#return_type' do
       subject(:return_type) { route_decorator.return_type.to_type_signature }
 

--- a/spec/lib/graphql_to_rest/schema/routes_to_components_schemas_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/routes_to_components_schemas_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe GraphqlToRest::Schema::RoutesToComponentsSchemas do
     it 'returns correct schemas for return type and inner enum types' do
       expect(call.keys).to match_array(%w[User GenderEnum Post])
     end
+
+    context 'when route has query parameters' do
+      let(:route) { build(:route_decorator, :users_paginated) }
+
+      it 'generates schemas for query parameters too' do
+        expect(call.keys).to match_array(%w[User UserConnection GenderEnum Post UsersFilter StatusEnum])
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds `graphql_input_type_path` to parameters, so now it's possible to user graphql types instead of duplicating the structure via yaml files

```ruby
class UsersController < ApiController
  open_api do |c|
    c.action(:index) do |a|
       a.query_paramerter('filter[status]')
        .graphql_input_type_path(%i[filter status)) # status might be enum, objects and etc.
  end
end
```