### PR TITLE
Add `#graphql_output_type_path` to ActionConfiguration

### DIFF
--- a/lib/graphql_to_rest/controller/basic/action_configuration.rb
+++ b/lib/graphql_to_rest/controller/basic/action_configuration.rb
@@ -44,6 +44,13 @@ module GraphqlToRest
           self
         end
 
+        def graphql_output_type_path(nesting = nil)
+          return @graphql_output_type_path || [] if nesting.nil?
+
+          @graphql_output_type_path = Array(nesting)
+          self
+        end
+
         def serializers
           @serializers ||= begin
             require 'graphql_to_rest/schema/basic/serializers'

--- a/lib/graphql_to_rest/schema/extract_nested_type.rb
+++ b/lib/graphql_to_rest/schema/extract_nested_type.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module GraphqlToRest
+  class Schema
+    # Extracts nested type from a given type by following given path of keys
+    class ExtractNestedType
+      method_object %i[type! nesting_keys!]
+
+      def call
+        nesting = nesting_keys.map(&:to_s)
+
+        nesting.reduce(type) do |type, key|
+          nested_field_type(type, key)
+        end
+      end
+
+      private
+
+      def nested_field_type(type, field)
+        final_type = type.respond_to?(:unwrap) ? type.unwrap : type
+        final_type = fields(final_type).fetch(field).type
+        final_type = type.respond_to?(:list?) && type.list? ? final_type.to_list_type : final_type
+        type.respond_to?(:non_null?) && type.non_null? ? final_type.to_non_null_type : final_type
+      end
+
+      def fields(type)
+        input_type? ? type.arguments : type.fields
+      end
+
+      def input_type?
+        type.respond_to?(:arguments)
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_to_rest/controller/json_api/action_configuration_spec.rb
+++ b/spec/lib/graphql_to_rest/controller/json_api/action_configuration_spec.rb
@@ -53,4 +53,24 @@ RSpec.describe GraphqlToRest::Controller::JsonApi::ActionConfiguration do
       end
     end
   end
+
+  describe '#graphql_output_type_path' do
+    subject(:graphql_output_type_path) { action_configuration.graphql_output_type_path }
+
+    context 'when path is not set' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when path is set' do
+      let(:path) { %i[path to nested field] }
+
+      before do
+        action_configuration.graphql_output_type_path(path)
+      end
+
+      it 'returns set path' do
+        expect(graphql_output_type_path).to eq(path)
+      end
+    end
+  end
 end

--- a/spec/lib/graphql_to_rest/schema/extract_nested_type_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/extract_nested_type_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphqlToRest::Schema::ExtractNestedType do
+  subject(:call) { described_class.call(type: type, nesting_keys: nesting_keys) }
+
+  let(:result_type) { call.to_type_signature }
+
+  describe '.call' do
+    context 'with type' do
+      let(:type) { GraphqlToRest::DummyAppShared::Types::UserType }
+
+      context 'with level 1 nesting' do
+        let(:nesting_keys) { %i[id] }
+
+        it 'returns nested type' do
+          expect(result_type).to eq('ID!')
+        end
+      end
+
+      context 'with level 2 nesting' do
+        let(:nesting_keys) { %i[posts id] }
+
+        it 'returns nested type' do
+          expect(result_type).to eq('[ID!]')
+        end
+      end
+    end
+
+    context 'with input type' do
+      let(:type) { GraphqlToRest::DummyAppShared::Types::UserCreateInputType }
+
+      context 'with level 1 nesting' do
+        let(:nesting_keys) { %i[email] }
+
+        it 'returns nested type' do
+          expect(result_type).to eq('String!')
+        end
+      end
+
+      context 'with level 2 nesting' do
+        let(:nesting_keys) { %i[location country] }
+
+        it 'returns nested type' do
+          expect(result_type).to eq('String!')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_to_rest/schema/route_decorator_spec.rb
+++ b/spec/lib/graphql_to_rest/schema/route_decorator_spec.rb
@@ -42,8 +42,32 @@ RSpec.describe GraphqlToRest::Schema::RouteDecorator do
     describe '#return_type' do
       subject(:return_type) { route_decorator.return_type.to_type_signature }
 
+      let(:rails_route) { build(:fake_rails_route, :users_paginated) }
+
       it 'returns correct return type' do
-        expect(return_type).to eq('User')
+        expect(return_type).to eq('UserConnection')
+      end
+
+      context 'when action is configured to point to a nested graphql type' do
+        context 'with 1 level nesting' do
+          before do
+            allow(route_decorator.action_config).to receive(:graphql_output_type_path).and_return(%i[nodes])
+          end
+
+          it 'returns nested return type' do
+            expect(return_type).to eq('[User]')
+          end
+        end
+
+        context 'with 2 level nesting' do
+          before do
+            allow(route_decorator.action_config).to receive(:graphql_output_type_path).and_return(%i[nodes id])
+          end
+
+          it 'returns nested return type' do
+            expect(return_type).to eq('[ID!]')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
I added `#graphql_output_type_path` method to `ActionConfiguration`. It is useful when an action implementation returns different type from what is written in schema.