### PR TITLE
Refs #HR-434: Allow overriding the model name for an action

### DIFF
--- a/lib/graphql_to_rest/controller/json_api/action_configuration.rb
+++ b/lib/graphql_to_rest/controller/json_api/action_configuration.rb
@@ -7,8 +7,8 @@ module GraphqlToRest
     module JsonApi
       # Configuration for OpenAPI controller action
       class ActionConfiguration < GraphqlToRest::Controller::Basic::ActionConfiguration
-        def model
-          controller_config.model
+        def model(name = nil)
+          @model ||= name.present? ? ModelConfiguration.new(name: name) : controller_config.model
         end
 
         def fieldset_parameter

--- a/spec/lib/graphql_to_rest/controller/json_api/action_configuration_spec.rb
+++ b/spec/lib/graphql_to_rest/controller/json_api/action_configuration_spec.rb
@@ -73,4 +73,26 @@ RSpec.describe GraphqlToRest::Controller::JsonApi::ActionConfiguration do
       end
     end
   end
+
+  describe '#model' do
+    subject(:model) { action_configuration.model }
+
+    before { controller_config.model('User') }
+
+    it 'returns the model configuration' do
+      expect(model).to be_a(GraphqlToRest::Controller::JsonApi::ModelConfiguration)
+    end
+
+    it 'inherits the model name from a controller configuration' do
+      expect(model.name).to eq('User')
+    end
+
+    context 'when the model name is provided' do
+      subject(:model) { action_configuration.model('AnotherResponse') }
+
+      it 'overrides the model name' do
+        expect(model.name).to eq('AnotherResponse')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, there is a need for a different response type for one of the actions.

This PR adds the ability to override the controller configuration's model name for an action configuration.